### PR TITLE
Fix for Property access on null or undefined

### DIFF
--- a/test/cypress/e2e/profile.spec.ts
+++ b/test/cypress/e2e/profile.spec.ts
@@ -74,9 +74,8 @@ describe('/profile', () => {
       cy.visit('http://htmledit.squarefree.com')
       /* The script executed below is equivalent to pasting this string into http://htmledit.squarefree.com: */
       /* <form action="http://localhost:3000/profile" method="POST"><input type="hidden" name="username" value="CSRF"/><input type="submit"/></form><script>document.forms[0].submit();</script> */
-      let document: any
-      cy.window().then(() => {
-        document
+      cy.window().then((win) => {
+        win.document
           .getElementsByName('editbox')[0]
           .contentDocument.getElementsByName(
             'ta'


### PR DESCRIPTION
To fix the problem, ensure the code inside `cy.window().then(...)` works with an actual `document` object. Cypress's `cy.window().then(cb)` passes the `window` object as the first argument to the callback. The correct usage is to capture this argument and use `window.document`. Specifically, in the callback on line 78, declare an argument (such as `win`) and replace `document` with `win.document`. Only the region relating to the callback surrounding lines 77–91 needs to be updated. No new imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._